### PR TITLE
Add padding to improve tap comfort

### DIFF
--- a/chess/UI/ChessGameView.swift
+++ b/chess/UI/ChessGameView.swift
@@ -13,6 +13,7 @@ struct ChessGameView: View {
 
     var body: some View {
         ChessBoardView(chessViewModel: self.chessViewModel)
+            .padding()
             .onAppear {
                 self.chessViewModel.gameAppeared()
             }


### PR DESCRIPTION
### Issue
It is easy to click on sides by mouse/trackpad, but touch controls require to respect system margin area. Usually it is 16 points but I assume it is better to rely not on on concrete number but rather on system value

### Explanation
From what I found [here](https://developer.apple.com/documentation/swiftui/view/padding(_:_:)) `.padding()` is what we want to use.
