### PR TITLE
Introduce game configuration

### DIFF
--- a/chess.xcodeproj/project.pbxproj
+++ b/chess.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0499CEAF2C413A850063B68F /* ChessGameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0499CEAE2C413A850063B68F /* ChessGameViewModel.swift */; };
 		0499CEB32C4146E60063B68F /* ChessBoardCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0499CEB22C4146E60063B68F /* ChessBoardCellView.swift */; };
 		B157A0DE2C40365600810FCC /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B157A0D62C40365500810FCC /* Preview Assets.xcassets */; };
 		B157A0DF2C40365600810FCC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B157A0D82C40365500810FCC /* Assets.xcassets */; };
@@ -17,10 +16,11 @@
 		B157A0E32C40365600810FCC /* ChessGameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B157A0DC2C40365500810FCC /* ChessGameView.swift */; };
 		B157A0E62C4039C200810FCC /* ChessBoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B157A0E52C4039C200810FCC /* ChessBoardView.swift */; };
 		B157A0E82C4039E100810FCC /* ChessPieceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B157A0E72C4039E100810FCC /* ChessPieceView.swift */; };
+		B157A0EA2C4271DD00810FCC /* BoardConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B157A0E92C4271DD00810FCC /* BoardConfiguration.swift */; };
+		B157A0EE2C42724A00810FCC /* ChessGameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B157A0ED2C42724A00810FCC /* ChessGameViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0499CEAE2C413A850063B68F /* ChessGameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ChessGameViewModel.swift; path = chess/ChessGameViewModel.swift; sourceTree = SOURCE_ROOT; };
 		0499CEB22C4146E60063B68F /* ChessBoardCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ChessBoardCellView.swift; path = Chess/UI/ChessBoardCellView.swift; sourceTree = SOURCE_ROOT; };
 		04A82C942C3D74E00073F6D1 /* Chess.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Chess.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B157A0D62C40365500810FCC /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -31,6 +31,8 @@
 		B157A0DC2C40365500810FCC /* ChessGameView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChessGameView.swift; sourceTree = "<group>"; };
 		B157A0E52C4039C200810FCC /* ChessBoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessBoardView.swift; sourceTree = "<group>"; };
 		B157A0E72C4039E100810FCC /* ChessPieceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessPieceView.swift; sourceTree = "<group>"; };
+		B157A0E92C4271DD00810FCC /* BoardConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardConfiguration.swift; sourceTree = "<group>"; };
+		B157A0ED2C42724A00810FCC /* ChessGameViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChessGameViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,9 +76,10 @@
 				B157A0D72C40365500810FCC /* Preview Content */,
 				B157A0D82C40365500810FCC /* Assets.xcassets */,
 				B157A0D92C40365500810FCC /* ChessApp.swift */,
+				B157A0ED2C42724A00810FCC /* ChessGameViewModel.swift */,
 				B157A0DB2C40365500810FCC /* ChessPiece.swift */,
 				B157A0DA2C40365500810FCC /* ChessGameModel.swift */,
-				0499CEAE2C413A850063B68F /* ChessGameViewModel.swift */,
+				B157A0E92C4271DD00810FCC /* BoardConfiguration.swift */,
 				B157A0E42C40399800810FCC /* UI */,
 			);
 			path = Chess;
@@ -128,7 +131,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 04A82C8F2C3D74E00073F6D1 /* Build configuration list for PBXProject "chess" */;
+			buildConfigurationList = 04A82C8F2C3D74E00073F6D1 /* Build configuration list for PBXProject "Chess" */;
 			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -164,11 +167,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				B157A0E82C4039E100810FCC /* ChessPieceView.swift in Sources */,
-				0499CEAF2C413A850063B68F /* ChessGameViewModel.swift in Sources */,
+				B157A0EA2C4271DD00810FCC /* BoardConfiguration.swift in Sources */,
 				B157A0E12C40365600810FCC /* ChessGameModel.swift in Sources */,
 				B157A0E02C40365600810FCC /* ChessApp.swift in Sources */,
 				0499CEB32C4146E60063B68F /* ChessBoardCellView.swift in Sources */,
 				B157A0E32C40365600810FCC /* ChessGameView.swift in Sources */,
+				B157A0EE2C42724A00810FCC /* ChessGameViewModel.swift in Sources */,
 				B157A0E22C40365600810FCC /* ChessPiece.swift in Sources */,
 				B157A0E62C4039C200810FCC /* ChessBoardView.swift in Sources */,
 			);
@@ -357,7 +361,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		04A82C8F2C3D74E00073F6D1 /* Build configuration list for PBXProject "chess" */ = {
+		04A82C8F2C3D74E00073F6D1 /* Build configuration list for PBXProject "Chess" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				04A82CA02C3D74E10073F6D1 /* Debug */,

--- a/chess/BoardConfiguration.swift
+++ b/chess/BoardConfiguration.swift
@@ -1,0 +1,70 @@
+//
+//  BoardConfiguration.swift
+//  Chess
+//
+//  Created by Andrius Shiaulis on 13.07.2024.
+//
+
+import Foundation
+
+enum BoardConfiguration {
+
+    // MARK: - Cases -
+
+    case minimal
+    case full
+
+    // MARK: - Public Methods -
+
+    func generateBoard() -> [[ChessPiece?]] {
+        switch self {
+        case .minimal: return generateMinimalBoard()
+        case .full: return generateFullBoard()
+        }
+    }
+
+    // MARK: - Private Methods -
+
+    private func generateMinimalBoard() -> [[ChessPiece?]] {
+        var board: [[ChessPiece?]] = .init(repeating: .init(repeating: nil, count: 8), count: 8)
+        board[2][4] = ChessPiece(kind: .pawn, color: .white)
+        return board
+    }
+
+    private func generateFullBoard() -> [[ChessPiece?]] {
+        var board: [[ChessPiece?]] = .init(repeating: .init(repeating: nil, count: 8), count: 8)
+        for col in 0...7 {
+            board[1][col] = ChessPiece(kind: .pawn, color: .black)
+            board[6][col] = ChessPiece(kind: .pawn, color: .white)
+        }
+
+        // rooks
+        board[0][0] = ChessPiece(kind: .rook, color: .black)
+        board[0][7] = ChessPiece(kind: .rook, color: .black)
+        board[7][0] = ChessPiece(kind: .rook, color: .white)
+        board[7][7] = ChessPiece(kind: .rook, color: .white)
+
+        // knights
+        board[0][1] = ChessPiece(kind: .knight, color: .black)
+        board[0][6] = ChessPiece(kind: .knight, color: .black)
+        board[7][1] = ChessPiece(kind: .knight, color: .white)
+        board[7][6] = ChessPiece(kind: .knight, color: .white)
+
+        // bishops
+        board[0][2] = ChessPiece(kind: .bishop, color: .black)
+        board[0][5] = ChessPiece(kind: .bishop, color: .black)
+        board[7][2] = ChessPiece(kind: .bishop, color: .white)
+        board[7][5] = ChessPiece(kind: .bishop, color: .white)
+
+        // queens
+        board[0][3] = ChessPiece(kind: .queen, color: .black)
+        board[7][3] = ChessPiece(kind: .queen, color: .white)
+
+        // kings
+        board[0][4] = ChessPiece(kind: .king, color: .black)
+        board[7][4] = ChessPiece(kind: .king, color: .white)
+
+        return board
+    }
+
+}

--- a/chess/ChessGameModel.swift
+++ b/chess/ChessGameModel.swift
@@ -9,39 +9,15 @@ import Foundation
 
 struct ChessGameModel {
 
+    enum GameMode {
+        case full
+        case pawn
+    }
+
     private(set) var board: [[ChessPiece?]] = .init(repeating: .init(repeating: nil, count: 8), count: 8)
 
-    mutating func createNewGameBoard() {
-        for col in 0...7 {
-            self.board[1][col] = ChessPiece(kind: .pawn, color: .black)
-            self.board[6][col] = ChessPiece(kind: .pawn, color: .white)
-        }
-
-        // rooks
-        self.board[0][0] = ChessPiece(kind: .rook, color: .black)
-        self.board[0][7] = ChessPiece(kind: .rook, color: .black)
-        self.board[7][0] = ChessPiece(kind: .rook, color: .white)
-        self.board[7][7] = ChessPiece(kind: .rook, color: .white)
-
-        // knights
-        self.board[0][1] = ChessPiece(kind: .knight, color: .black)
-        self.board[0][6] = ChessPiece(kind: .knight, color: .black)
-        self.board[7][1] = ChessPiece(kind: .knight, color: .white)
-        self.board[7][6] = ChessPiece(kind: .knight, color: .white)
-
-        // bishops
-        self.board[0][2] = ChessPiece(kind: .bishop, color: .black)
-        self.board[0][5] = ChessPiece(kind: .bishop, color: .black)
-        self.board[7][2] = ChessPiece(kind: .bishop, color: .white)
-        self.board[7][5] = ChessPiece(kind: .bishop, color: .white)
-
-        // queens
-        self.board[0][3] = ChessPiece(kind: .queen, color: .black)
-        self.board[7][3] = ChessPiece(kind: .queen, color: .white)
-
-        // kings
-        self.board[0][4] = ChessPiece(kind: .king, color: .black)
-        self.board[7][4] = ChessPiece(kind: .king, color: .white)
+    mutating func createNewGameBoard(configuration: BoardConfiguration) {
+        self.board = configuration.generateBoard()
     }
 
     mutating func move(from: Coordinate, to: Coordinate) {

--- a/chess/ChessGameViewModel.swift
+++ b/chess/ChessGameViewModel.swift
@@ -13,7 +13,7 @@ final class ChessGameViewModel: ObservableObject {
     @Published private var model = ChessGameModel()
 
     func gameAppeared() {
-        self.model.createNewGameBoard()
+        self.model.createNewGameBoard(configuration: .full)
     }
 
     func cellTapped(at cellAddress: Coordinate) {


### PR DESCRIPTION
This PR introduces new type that is needed for future experiments - `BoardConfiguration`. It contains description of chess pieces and their locations on the board. The current configuration is `full`, but to play around with pawn promotion I will also need a `minimal` configuration where only 1 pawn is on the board. Related to #10 

You can test it by checking if currently game plays the same.
You can also set `minimal` configuration where only 1 pawn will be shown