### PR TITLE
Add board rotation for player color

### DIFF
--- a/chess/BoardConfiguration.swift
+++ b/chess/BoardConfiguration.swift
@@ -33,38 +33,23 @@ enum BoardConfiguration {
 
     private func generateFullBoard() -> [[ChessPiece?]] {
         var board: [[ChessPiece?]] = .init(repeating: .init(repeating: nil, count: 8), count: 8)
+
+        // Place pawns
         for col in 0...7 {
             board[1][col] = ChessPiece(kind: .pawn, color: .black)
             board[6][col] = ChessPiece(kind: .pawn, color: .white)
         }
 
-        // rooks
-        board[0][0] = ChessPiece(kind: .rook, color: .black)
-        board[0][7] = ChessPiece(kind: .rook, color: .black)
-        board[7][0] = ChessPiece(kind: .rook, color: .white)
-        board[7][7] = ChessPiece(kind: .rook, color: .white)
+        let pieceOrder: [ChessPiece.Kind] = [.rook, .knight, .bishop, .queen, .king, .bishop, .knight, .rook]
 
-        // knights
-        board[0][1] = ChessPiece(kind: .knight, color: .black)
-        board[0][6] = ChessPiece(kind: .knight, color: .black)
-        board[7][1] = ChessPiece(kind: .knight, color: .white)
-        board[7][6] = ChessPiece(kind: .knight, color: .white)
-
-        // bishops
-        board[0][2] = ChessPiece(kind: .bishop, color: .black)
-        board[0][5] = ChessPiece(kind: .bishop, color: .black)
-        board[7][2] = ChessPiece(kind: .bishop, color: .white)
-        board[7][5] = ChessPiece(kind: .bishop, color: .white)
-
-        // queens
-        board[0][3] = ChessPiece(kind: .queen, color: .black)
-        board[7][3] = ChessPiece(kind: .queen, color: .white)
-
-        // kings
-        board[0][4] = ChessPiece(kind: .king, color: .black)
-        board[7][4] = ChessPiece(kind: .king, color: .white)
+        // Place other pieces
+        for col in 0...7 {
+            board[0][col] = ChessPiece(kind: pieceOrder[col], color: .black)
+            board[7][col] = ChessPiece(kind: pieceOrder[col], color: .white)
+        }
 
         return board
     }
+
 
 }

--- a/chess/ChessGameViewModel.swift
+++ b/chess/ChessGameViewModel.swift
@@ -72,8 +72,12 @@ final class ChessGameViewModel: ObservableObject {
         (cellAddress.row + cellAddress.col).isMultiple(of: 2) ? .white : .black
     }
 
+    func getPlayerColor() -> ChessPiece.Color {
+        self.model.player?.color ?? .white
+    }
+
     private func makeNewGame() {
-        self.model.createNewGameBoard(configuration: .full)
+        self.model.setup()
 
         self.model.$board
             .receive(on: DispatchQueue.main)

--- a/chess/ChessPiece.swift
+++ b/chess/ChessPiece.swift
@@ -19,8 +19,17 @@ struct ChessPiece: Equatable, CustomStringConvertible {
     }
 
     enum Color: String {
-        case white = "W"
-        case black = "B"
+        case white
+        case black
+
+        var shorthand: String {
+            switch self {
+            case .white:
+                return "W"
+            case .black:
+                return "B"
+            }
+        }
     }
 
     let kind: Kind

--- a/chess/ChessPlayer.swift
+++ b/chess/ChessPlayer.swift
@@ -7,17 +7,13 @@
 
 import Foundation
 
-enum ChessColor: String {
-    case black
-    case white
-}
 
 final class ChessPlayer {
 
-    let color: ChessColor
+    let color: ChessPiece.Color
     var isMyTurn: Bool
 
-    init(color: ChessColor, isMyTurn: Bool) {
+    init(color: ChessPiece.Color, isMyTurn: Bool) {
         self.color = color
         self.isMyTurn = isMyTurn
     }

--- a/chess/UI/ChessBoardView.swift
+++ b/chess/UI/ChessBoardView.swift
@@ -35,6 +35,7 @@ struct ChessBoardView: View {
                             )
                             if let piece = self.chessViewModel.getPiece(for: cellAddress) {
                                 ChessPieceView(piece: piece, imageSize: cellWidth * 0.9)
+                                    .rotationEffect(self.chessViewModel.getPlayerColor() == .black ? .degrees(180) : .degrees(0))
                             }
                         }
                         .onTapGesture {
@@ -47,6 +48,7 @@ struct ChessBoardView: View {
                 .position(x: geometry.frame(in: .local).midX, y: geometry.frame(in: .local).midY)
             }
         }
+        .rotationEffect(self.chessViewModel.getPlayerColor() == .black ? .degrees(180) : .degrees(0))
     }
 
 }

--- a/chess/UI/ChessPieceView.swift
+++ b/chess/UI/ChessPieceView.swift
@@ -20,7 +20,7 @@ struct ChessPieceView: View {
     }
 
     var body: some View {
-        Image(piece.color.rawValue + piece.kind.rawValue)
+        Image(piece.color.shorthand + piece.kind.rawValue)
             .resizable()
             .frame(width: self.imageSize, height: self.imageSize, alignment: .center)
     }


### PR DESCRIPTION
- Added rotation effect to the board and pieces (so they are not upside down on the rotated board)
- Removed player color enum since it was duplicating chess piece color (refactored chess piece color so it works for both cases) 
- Moved board generation to the moment after we receive color 
- Refactored board generation on the go
